### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,11 @@ jobs:
       - name: Use Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.13.x
+          go-version: 1.17.x
 
       - name: build game
         run: |
+          go env -w GO111MODULE=off
           go get github.com/tmedwards/tweego
           export PATH=$PATH:$(go env GOPATH)/bin
           mkdir -p ${{vars.OUTPUT_DIRECTORY}} && touch ${{vars.OUTPUT_DIRECTORY}}/${{vars.OUTPUT_FILENAME}}


### PR DESCRIPTION
I found that the build.yml file was not "getting" the Tweego repo correctly and therefore wouldn't compile my Twine files. I did a bit of digging and found that upgrading to Go version 1.17.* and adding
`go env -w GO111MODULE=off`
to the 'build game' job fixed that error for me. 

![builderror](https://github.com/6notes/tweeExample/assets/165116997/4b036182-eb95-41ee-870a-0bfd4be69d13)

It seems that Tweego will only compile with a version of Go that predates modules - and 1.13 was not automatically setting the GO111MODULE to off.
Feel free to reject this - but I forked your repository to see if your build.yml file was generating a similar error (and it was). I figured you might appreciate this workaround.